### PR TITLE
Add peers section to the configuration

### DIFF
--- a/templates/basic/49-peers.cfg.tmpl
+++ b/templates/basic/49-peers.cfg.tmpl
@@ -1,0 +1,9 @@
+# basic/49-peers.cfg.tmpl
+
+peers haproxies
+{{- range $peer := ls "/self/stack/services/haproxy/containers" }}
+  {{- $container := getv (printf "/services/haproxy/containers/%s/external_id" $peer) }}
+  {{- $ip := getv (printf "/services/haproxy/containers/%s/ips/0" $peer) }}
+  peer {{ printf "%.12s" $container }} {{ $ip }}:1024
+{{- end }}
+

--- a/templates/common/04-peers.cfg
+++ b/templates/common/04-peers.cfg
@@ -1,4 +1,4 @@
-# basic/49-peers.cfg.tmpl
+# common/04-peers.cfg
 
 peers haproxies
 {{- range $peer := ls "/self/stack/services/haproxy/containers" }}

--- a/templates/common/04-peers.cfg
+++ b/templates/common/04-peers.cfg
@@ -1,6 +1,9 @@
 # common/04-peers.cfg
 
 peers haproxies
+{{- if (ne "true" (getv "/self/service/labels/lb.haproxy_enable_peers" "false")) }}
+  disabled
+{{- end }}
 {{- range $peer := ls "/self/stack/services/haproxy/containers" }}
   {{- $container := getv (printf "/services/haproxy/containers/%s/external_id" $peer) }}
   {{- $ip := getv (printf "/services/haproxy/containers/%s/ips/0" $peer) }}


### PR DESCRIPTION
My first commit is a work in progress. I'm not sure how to add this configuration. I will need it with the backends config in `templates/basic` but it shouldn't be added by default, and duplicating the content of `templates/basic` doesn't seem right either.

The peers list that is generated uses the docker id of containers as peer names, which means that every haproxy instance should find its own entry in the list based on the container's hostname (no need for the `-L` argument on the command line).