### PR TITLE
common: fix config test with peers using fake entry

### DIFF
--- a/templates/common/04-peers.cfg
+++ b/templates/common/04-peers.cfg
@@ -4,6 +4,7 @@ peers haproxies
 {{- if (ne "true" (getv "/self/service/labels/lb.haproxy_enable_peers" "false")) }}
   disabled
 {{- end }}
+  peer haproxy-rancher-confd-check 127.0.0.1:1025
 {{- range $peer := ls "/self/stack/services/haproxy/containers" }}
   {{- $container := getv (printf "/services/haproxy/containers/%s/external_id" $peer) }}
   {{- $ip := getv (printf "/services/haproxy/containers/%s/ips/0" $peer) }}

--- a/templates/reverse-proxy.toml
+++ b/templates/reverse-proxy.toml
@@ -6,5 +6,5 @@ keys = [
   "/stacks",
   "/self",
 ]
-check_cmd = "haproxy -c -f {{ .src }}"
+check_cmd = "haproxy -c -f {{ .src }} -L haproxy-rancher-confd-check"
 reload_cmd = "pkill -USR2 -o -e -f '^haproxy\\s.*-f\\s+/usr/local/etc/haproxy/reverse-proxy.cfg'"


### PR DESCRIPTION
Config is accepted by haproxy, but I don't know if the fake entry can cause troube (doc doesn't say anything about that).